### PR TITLE
Fix sftp path in backup_method.j2

### DIFF
--- a/conf/backup_method.j2
+++ b/conf/backup_method.j2
@@ -11,7 +11,7 @@ RESTIC_SERVER_USER=$(yunohost app setting {{ app }} ssh_user)
 RESTIC_PATH=$(yunohost app setting {{ app }} backup_path)
 
 RESTIC_PASSWORD="$(yunohost app setting {{ app }} passphrase)"
-RESTIC_REPOSITORY_BASE=sftp://$RESTIC_SERVER_USER@$RESTIC_SERVER:$RESTIC_SERVER_PORT/$RESTIC_PATH/
+RESTIC_REPOSITORY_BASE=sftp:$RESTIC_SERVER_USER@$RESTIC_SERVER:$RESTIC_SERVER_PORT/$RESTIC_PATH
 
 RESTIC_COMMAND={{ install_dir }}/{{ app }}
 LOGFILE=/var/log/restic_backup_{{ app }}.log


### PR DESCRIPTION
fixed the sftp path by removing the forward slash and the protocol slash. sftp doesn't use sftp://host but sftp:host

## Problem

- *The SFTP path was not formatted correctly and led to errors*

## Solution

- *Removed the forward slashes*

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
